### PR TITLE
fix: ENOENT while executing install.mjs on windows

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -2,7 +2,7 @@
 
 import fs from "node:fs/promises"
 import path from "node:path";
-
+import { fileURLToPath } from "node:url";
 // If this program is running on node-altjtalk-binding repo,
 // do not download prebuilt binary
 const isRepo = await fs.access("build.rs").then(() => true, () => false);
@@ -26,7 +26,7 @@ async function isMusl() {
 
 const baseUrl = "https://github.com/femshima/node-altjtalk-binding/releases/download";
 
-const file = new URL(import.meta.url).pathname;
+const file = fileURLToPath(import.meta.url);
 const dir = path.dirname(file);
 
 const packageJSON = JSON.parse(


### PR DESCRIPTION
```
[Error: ENOENT: no such file or directory, open 'D:\D:\develop\om\node_modules\node-altjtalk-binding\package.json'] {
530 error   errno: -4058,
530 error   code: 'ENOENT',
530 error   syscall: 'open',
530 error   path: 'D:\D:\develop\om\node_modules\node-altjtalk-binding\package.json'
530 error }
```

ref: https://nodejs.org/api/url.html#url_url_fileurltopath_url