### PR TITLE
Change copyright holder to `Discord.js Japan User Group`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 phenylshima
+Copyright (c) 2024 Discord.js Japan User Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
このリポジトリの著作権者を「Discord.js Japan User Group」とすることを提案します．